### PR TITLE
Revise dashboard and add planet management

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,7 @@ import {
   DiscoveryQueryParams,
   MethodCountSchema,
   OpenApiDocumentSchema,
+  PlanetCreateInput,
   PlanetCountSchema,
   PlanetListParams,
   PlanetListResponse,
@@ -138,6 +139,33 @@ export const fetchPlanetById = async (planetId: number): Promise<PlanetRow> => {
 export const fetchPlanetByName = async (name: string): Promise<PlanetRow> => {
   const payload = await http<unknown>(`/planets/by-name/${encodeURIComponent(name)}`)
   return PlanetRowSchema.parse(payload)
+}
+
+/**
+ * Creates a new planet entry within the catalogue.
+ *
+ * @param payload - Planet attributes to persist.
+ * @returns The created planet row.
+ */
+export const createPlanet = async (payload: PlanetCreateInput): Promise<PlanetRow> => {
+  const response = await http<unknown>('/planets/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  return PlanetRowSchema.parse(response)
+}
+
+/**
+ * Soft deletes a planet by identifier.
+ *
+ * @param planetId - Numeric identifier of the planet to delete.
+ */
+export const deletePlanet = async (planetId: number): Promise<void> => {
+  await http<void>(`/planets/${planetId}`, withAdminAuth({ method: 'DELETE' }))
 }
 
 /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -37,6 +37,19 @@ export const PlanetRowSchema = z
 /** Planet entry as consumed by the UI table. */
 export type PlanetRow = z.infer<typeof PlanetRowSchema>
 
+/** Payload accepted by the create planet endpoint. */
+export interface PlanetCreateInput {
+  name: string
+  disc_method?: string
+  disc_year?: number
+  orbperd?: number
+  rade?: number
+  masse?: number
+  st_teff?: number
+  st_rad?: number
+  st_mass?: number
+}
+
 /** Schema capturing the paginated response envelope for the planet list endpoint. */
 export const PlanetListResponseSchema = z
   .object({

--- a/src/components/PlanetManagement.tsx
+++ b/src/components/PlanetManagement.tsx
@@ -1,0 +1,324 @@
+import { useState, type CSSProperties } from 'react'
+import type { PlanetCreateInput } from '../api/types'
+import { isApiError } from '../api/http'
+import { useCreatePlanet, useDeletePlanet } from '../hooks/usePlanets'
+
+export interface PlanetManagementProps {
+  buttonStyle: CSSProperties
+}
+
+const sectionStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  marginTop: '2.5rem',
+}
+
+const gridStyle: CSSProperties = {
+  display: 'grid',
+  gap: '1.5rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+}
+
+const cardStyle: CSSProperties = {
+  background: 'rgba(15, 23, 42, 0.75)',
+  border: '1px solid rgba(148, 163, 184, 0.25)',
+  borderRadius: '1rem',
+  padding: '1.5rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  boxShadow: '0 20px 45px rgba(15, 23, 42, 0.35)',
+}
+
+const formStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+}
+
+const labelStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.35rem',
+  fontSize: '0.85rem',
+  color: 'rgba(226, 232, 240, 0.8)',
+}
+
+const inputStyle: CSSProperties = {
+  padding: '0.65rem 0.75rem',
+  borderRadius: '0.75rem',
+  border: '1px solid rgba(148, 163, 184, 0.35)',
+  background: 'rgba(15, 23, 42, 0.6)',
+  color: '#f8fafc',
+}
+
+const helperTextStyle: CSSProperties = {
+  fontSize: '0.75rem',
+  color: 'rgba(148, 163, 184, 0.85)',
+}
+
+const feedbackStyle: CSSProperties = {
+  fontSize: '0.85rem',
+}
+
+const toOptionalNumber = (value: string): number | undefined => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const normalisePayload = (form: PlanetCreateInput): PlanetCreateInput => {
+  const payload: PlanetCreateInput = {
+    name: form.name.trim(),
+  }
+
+  if (form.disc_method?.trim()) {
+    payload.disc_method = form.disc_method.trim()
+  }
+
+  if (typeof form.disc_year === 'number' && Number.isFinite(form.disc_year)) {
+    payload.disc_year = form.disc_year
+  }
+
+  return payload
+}
+
+const formatErrorMessage = (error: unknown): string => {
+  if (isApiError(error)) {
+    const details = (error.details as { detail?: unknown })?.detail
+    if (typeof details === 'string' && details.length > 0) {
+      return details
+    }
+
+    if (Array.isArray(details) && details.length > 0) {
+      const first = details[0] as { msg?: string }
+      if (typeof first?.msg === 'string') {
+        return first.msg
+      }
+    }
+
+    return error.message
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return 'Unexpected error while communicating with the API.'
+}
+
+interface FeedbackState {
+  status: 'success' | 'error'
+  message: string
+}
+
+export const PlanetManagement = ({ buttonStyle }: PlanetManagementProps) => {
+  const createMutation = useCreatePlanet()
+  const deleteMutation = useDeletePlanet()
+
+  const [createForm, setCreateForm] = useState({
+    name: '',
+    disc_method: '',
+    disc_year: '',
+  })
+  const [deleteId, setDeleteId] = useState('')
+  const [createFeedback, setCreateFeedback] = useState<FeedbackState | null>(null)
+  const [deleteFeedback, setDeleteFeedback] = useState<FeedbackState | null>(null)
+
+  return (
+    <section style={sectionStyle} aria-labelledby="planet-management-heading">
+      <header>
+        <h2 id="planet-management-heading" style={{ marginBottom: '0.35rem' }}>
+          Manage planets
+        </h2>
+        <p style={{ ...helperTextStyle, margin: 0 }}>
+          Create new catalogue entries or trigger soft deletion using the official API endpoints.
+        </p>
+      </header>
+
+      <div style={gridStyle}>
+        <article style={cardStyle}>
+          <div>
+            <h3 style={{ margin: 0 }}>Add a planet</h3>
+            <p style={helperTextStyle}>POST /planets/</p>
+          </div>
+          <form
+            style={formStyle}
+            onSubmit={(event) => {
+              event.preventDefault()
+              setCreateFeedback(null)
+
+              const name = createForm.name.trim()
+              if (!name) {
+                setCreateFeedback({ status: 'error', message: 'Planet name is required.' })
+                return
+              }
+
+              const discYear = toOptionalNumber(createForm.disc_year)
+              if (createForm.disc_year.trim().length > 0 && discYear === undefined) {
+                setCreateFeedback({ status: 'error', message: 'Discovery year must be a valid number.' })
+                return
+              }
+
+              const payload = normalisePayload({
+                name,
+                disc_method: createForm.disc_method,
+                disc_year: discYear,
+              })
+
+              createMutation.mutate(payload, {
+                onSuccess: (planet) => {
+                  setCreateFeedback({
+                    status: 'success',
+                    message: `Planet “${planet.name}” created with ID ${planet.id}.`,
+                  })
+                  setCreateForm({ name: '', disc_method: '', disc_year: '' })
+                },
+                onError: (error) => {
+                  setCreateFeedback({ status: 'error', message: formatErrorMessage(error) })
+                },
+              })
+            }}
+          >
+            <label style={labelStyle}>
+              Planet name
+              <input
+                required
+                style={inputStyle}
+                type="text"
+                value={createForm.name}
+                onChange={(event) => setCreateForm((state) => ({ ...state, name: event.target.value }))}
+                placeholder="e.g. Kepler-452 b"
+              />
+            </label>
+            <label style={labelStyle}>
+              Discovery method
+              <input
+                style={inputStyle}
+                type="text"
+                value={createForm.disc_method}
+                onChange={(event) =>
+                  setCreateForm((state) => ({ ...state, disc_method: event.target.value }))
+                }
+                placeholder="Transit, Radial Velocity, ..."
+              />
+            </label>
+            <label style={labelStyle}>
+              Discovery year
+              <input
+                style={inputStyle}
+                type="number"
+                inputMode="numeric"
+                value={createForm.disc_year}
+                onChange={(event) =>
+                  setCreateForm((state) => ({ ...state, disc_year: event.target.value }))
+                }
+                placeholder="2024"
+              />
+            </label>
+            <button
+              type="submit"
+              style={buttonStyle}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create planet'}
+            </button>
+            <p
+              style={{
+                ...feedbackStyle,
+                color:
+                  createFeedback?.status === 'error'
+                    ? '#fca5a5'
+                    : createFeedback?.status === 'success'
+                      ? '#86efac'
+                      : 'transparent',
+                minHeight: '1.2em',
+                margin: 0,
+              }}
+              role="status"
+              aria-live="polite"
+            >
+              {createFeedback?.message ?? ''}
+            </p>
+          </form>
+        </article>
+
+        <article style={cardStyle}>
+          <div>
+            <h3 style={{ margin: 0 }}>Remove a planet</h3>
+            <p style={helperTextStyle}>DELETE /planets/{{planet_id}}</p>
+          </div>
+          <form
+            style={formStyle}
+            onSubmit={(event) => {
+              event.preventDefault()
+              setDeleteFeedback(null)
+
+              const planetId = toOptionalNumber(deleteId)
+              if (planetId === undefined) {
+                setDeleteFeedback({ status: 'error', message: 'Enter a valid numeric planet ID.' })
+                return
+              }
+
+              deleteMutation.mutate(planetId, {
+                onSuccess: () => {
+                  setDeleteFeedback({
+                    status: 'success',
+                    message: `Planet ${planetId} queued for soft deletion.`,
+                  })
+                  setDeleteId('')
+                },
+                onError: (error) => {
+                  setDeleteFeedback({ status: 'error', message: formatErrorMessage(error) })
+                },
+              })
+            }}
+          >
+            <label style={labelStyle}>
+              Planet ID
+              <input
+                style={inputStyle}
+                type="number"
+                inputMode="numeric"
+                value={deleteId}
+                onChange={(event) => setDeleteId(event.target.value)}
+                placeholder="1234"
+              />
+              <span style={helperTextStyle}>
+                Soft deletion requires an admin key when the API is configured to enforce it.
+              </span>
+            </label>
+            <button
+              type="submit"
+              style={buttonStyle}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete planet'}
+            </button>
+            <p
+              style={{
+                ...feedbackStyle,
+                color:
+                  deleteFeedback?.status === 'error'
+                    ? '#fca5a5'
+                    : deleteFeedback?.status === 'success'
+                      ? '#86efac'
+                      : 'transparent',
+                minHeight: '1.2em',
+                margin: 0,
+              }}
+              role="status"
+              aria-live="polite"
+            >
+              {deleteFeedback?.message ?? ''}
+            </p>
+          </form>
+        </article>
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/usePlanets.ts
+++ b/src/hooks/usePlanets.ts
@@ -2,8 +2,10 @@
  * React Query hooks that encapsulate planet catalogue data access patterns.
  */
 
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
+  createPlanet,
+  deletePlanet,
   fetchMethodCounts,
   fetchMethodStats,
   fetchDeletedPlanets,
@@ -22,6 +24,7 @@ import type {
   PlanetRow,
   PlanetSortField,
   PlanetSortOrder,
+  PlanetCreateInput,
   PlanetStats,
   PlanetTimelineParams,
   PlanetTimelinePoint,
@@ -270,3 +273,37 @@ export const useDeletedPlanets = (enabled: boolean) =>
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
   })
+
+/**
+ * Creates a planet and refreshes cached queries on success.
+ *
+ * @returns A mutation hook for planet creation.
+ */
+export const useCreatePlanet = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationKey: ['planets', 'create'],
+    mutationFn: (payload: PlanetCreateInput) => createPlanet(payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['planets'] })
+    },
+  })
+}
+
+/**
+ * Soft deletes a planet and invalidates cached queries on success.
+ *
+ * @returns A mutation hook for planet deletion.
+ */
+export const useDeletePlanet = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationKey: ['planets', 'delete'],
+    mutationFn: (planetId: number) => deletePlanet(planetId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['planets'] })
+    },
+  })
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,43 +1,18 @@
-import { useMemo, useState } from 'react'
-import { BarChart } from '../components/BarChart'
+import { useMemo, type CSSProperties } from 'react'
 import { ErrorState } from '../components/ErrorState'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { MetricCard } from '../components/MetricCard'
-import { TimelineChart } from '../components/TimelineChart'
-import { useMethodCounts, usePlanetCount, usePlanetStats, usePlanetTimeline } from '../hooks/usePlanets'
-import type { PlanetTimelineParams } from '../api/types'
+import { PlanetManagement } from '../components/PlanetManagement'
+import { usePlanetCount } from '../hooks/usePlanets'
 
 const numberFormatter = new Intl.NumberFormat('en-US')
-const decimalFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })
-
-const kpiGridStyle: React.CSSProperties = {
+const kpiGridStyle: CSSProperties = {
   display: 'grid',
   gap: '1.5rem',
   gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
 }
 
-const sectionStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1rem',
-  marginTop: '2rem',
-}
-
-const sectionHeaderStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  flexWrap: 'wrap',
-  gap: '1rem',
-}
-
-const timelineControlsStyle: React.CSSProperties = {
-  display: 'flex',
-  gap: '0.75rem',
-  flexWrap: 'wrap',
-}
-
-const buttonStyle: React.CSSProperties = {
+const buttonStyle: CSSProperties = {
   background: 'linear-gradient(135deg, #38bdf8, #6366f1)',
   color: '#0f172a',
   fontWeight: 600,
@@ -45,30 +20,15 @@ const buttonStyle: React.CSSProperties = {
 
 const cardPlaceholder = <LoadingSkeleton height="4.5rem" />
 
-const toNumber = (value: string): number | undefined => {
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : undefined
-}
-
 /**
- * Dashboard landing page displaying KPIs, timeline, and method breakdowns.
+ * Dashboard landing page displaying KPIs and quick management tools.
  *
  * @returns The dashboard route element.
  */
 const DashboardPage = () => {
-  const [timelineForm, setTimelineForm] = useState<{ start: string; end: string }>({ start: '', end: '' })
-  const [timelineParams, setTimelineParams] = useState<PlanetTimelineParams>({})
-
   const countQuery = usePlanetCount()
-  const statsQuery = usePlanetStats()
-  const methodCountsQuery = useMethodCounts()
-  const timelineQuery = usePlanetTimeline(timelineParams)
-
   const cards = useMemo(() => {
     const count = countQuery.data?.total
-    const newest = statsQuery.data?.disc_year?.max
-    const avgRadius = statsQuery.data?.rade?.avg ?? statsQuery.data?.rade?.mean
-    const avgMass = statsQuery.data?.masse?.avg ?? statsQuery.data?.masse?.mean
 
     return [
       {
@@ -77,61 +37,25 @@ const DashboardPage = () => {
         hint: 'Total planets tracked by the API',
         loading: countQuery.isLoading,
       },
-      {
-        title: 'Newest discovery year',
-        value: typeof newest === 'number' ? numberFormatter.format(newest) : '—',
-        hint: 'Latest confirmed discovery in the catalogue',
-        loading: statsQuery.isLoading,
-      },
-      {
-        title: 'Average planet radius',
-        value: typeof avgRadius === 'number' ? `${decimalFormatter.format(avgRadius)} R⊕` : '—',
-        hint: 'Mean planetary radius across the dataset',
-        loading: statsQuery.isLoading,
-      },
-      {
-        title: 'Average planet mass',
-        value: typeof avgMass === 'number' ? `${decimalFormatter.format(avgMass)} M⊕` : '—',
-        hint: 'Mean planetary mass across the dataset',
-        loading: statsQuery.isLoading,
-      },
     ]
-  }, [countQuery.data?.total, countQuery.isLoading, statsQuery.data, statsQuery.isLoading])
-
-  const methodChartData = useMemo(
-    () =>
-      methodCountsQuery.data?.map((item) => ({
-        name: item.method,
-        value: item.count,
-      })) ?? [],
-    [methodCountsQuery.data],
-  )
-
-  const applyTimelineFilters = () => {
-    setTimelineParams({
-      start_year: toNumber(timelineForm.start),
-      end_year: toNumber(timelineForm.end),
-    })
-  }
+  }, [countQuery.data?.total, countQuery.isLoading])
 
   return (
     <div>
       <header style={{ marginBottom: '2rem' }}>
         <h1 style={{ fontSize: '2.25rem', marginBottom: '0.25rem' }}>Exoplanet Observatory</h1>
         <p style={{ color: 'rgba(226, 232, 240, 0.7)', maxWidth: 640 }}>
-          Explore discovery trends, aggregate statistics, and discovery methods from the live
-          catalogue.
+          Review catalogue totals and manage planets directly using the live API.
         </p>
       </header>
 
-      {countQuery.isError || statsQuery.isError ? (
+      {countQuery.isError ? (
         <ErrorState
-          error={countQuery.error ?? statsQuery.error}
+          error={countQuery.error}
           title="Unable to load dashboard metrics"
           action={
             <button style={buttonStyle} onClick={() => {
               void countQuery.refetch()
-              void statsQuery.refetch()
             }}
             >
               Retry
@@ -151,94 +75,7 @@ const DashboardPage = () => {
         </div>
       )}
 
-      <section style={sectionStyle}>
-        <div style={sectionHeaderStyle}>
-          <div>
-            <h2 style={{ margin: 0 }}>Discovery timeline</h2>
-            <p style={{ color: 'rgba(226, 232, 240, 0.7)', margin: 0 }}>
-              Number of confirmed planets discovered per calendar year.
-            </p>
-          </div>
-          <form
-            style={timelineControlsStyle}
-            onSubmit={(event) => {
-              event.preventDefault()
-              applyTimelineFilters()
-            }}
-          >
-            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.85rem' }}>
-              Start year
-              <input
-                type="number"
-                inputMode="numeric"
-                value={timelineForm.start}
-                onChange={(event) =>
-                  setTimelineForm((state) => ({ ...state, start: event.target.value }))
-                }
-              />
-            </label>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.85rem' }}>
-              End year
-              <input
-                type="number"
-                inputMode="numeric"
-                value={timelineForm.end}
-                onChange={(event) => setTimelineForm((state) => ({ ...state, end: event.target.value }))}
-              />
-            </label>
-            <button type="submit" style={buttonStyle}>
-              Update
-            </button>
-          </form>
-        </div>
-
-        {timelineQuery.isError ? (
-          <ErrorState
-            error={timelineQuery.error}
-            title="Unable to load timeline"
-            action={
-              <button style={buttonStyle} onClick={() => void timelineQuery.refetch()}>
-                Retry
-              </button>
-            }
-          />
-        ) : timelineQuery.isLoading ? (
-          <LoadingSkeleton height="320px" />
-        ) : timelineQuery.data && timelineQuery.data.length > 0 ? (
-          <TimelineChart data={timelineQuery.data} />
-        ) : (
-          <p style={{ color: 'rgba(226, 232, 240, 0.6)' }}>No timeline data available.</p>
-        )}
-      </section>
-
-      <section style={sectionStyle}>
-        <div style={sectionHeaderStyle}>
-          <div>
-            <h2 style={{ margin: 0 }}>Discovery methods</h2>
-            <p style={{ color: 'rgba(226, 232, 240, 0.7)', margin: 0 }}>
-              Top discovery methods ranked by total confirmed planets.
-            </p>
-          </div>
-        </div>
-
-        {methodCountsQuery.isError ? (
-          <ErrorState
-            error={methodCountsQuery.error}
-            title="Unable to load method breakdown"
-            action={
-              <button style={buttonStyle} onClick={() => void methodCountsQuery.refetch()}>
-                Retry
-              </button>
-            }
-          />
-        ) : methodCountsQuery.isLoading ? (
-          <LoadingSkeleton height="320px" />
-        ) : methodChartData.length > 0 ? (
-          <BarChart data={methodChartData} title="Discovery methods" />
-        ) : (
-          <p style={{ color: 'rgba(226, 232, 240, 0.6)' }}>No discovery method data available.</p>
-        )}
-      </section>
+      <PlanetManagement buttonStyle={buttonStyle} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the broken timeline and discovery method charts from the dashboard and focus the hero copy on catalogue management
- introduce a planet management panel with forms to call POST /planets/ and DELETE /planets/{id}
- extend the API layer and hooks with create/delete helpers and mutation wiring for cache invalidation

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d02c37cc90832a94bc9994b59c3bf7