### PR TITLE
Revamp dashboard and add planet management

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,7 @@ import {
   DiscoveryQueryParams,
   MethodCountSchema,
   OpenApiDocumentSchema,
+  PlanetCreateInput,
   PlanetCountSchema,
   PlanetListParams,
   PlanetListResponse,
@@ -84,6 +85,25 @@ export const fetchPlanetStats = async (): Promise<PlanetStats> => {
 }
 
 /**
+ * Creates a new planet record in the catalogue.
+ *
+ * @param payload - Minimal planet details to persist.
+ * @returns The created planet row as stored by the API.
+ */
+export const createPlanet = async (payload: PlanetCreateInput): Promise<PlanetRow> => {
+  const body = JSON.stringify(payload)
+  const response = await http<unknown>(
+    '/planets/',
+    withAdminAuth({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    }),
+  )
+  return PlanetRowSchema.parse(response)
+}
+
+/**
  * Retrieves the number of planets grouped by discovery method.
  *
  * @returns An array of method/count tuples.
@@ -138,6 +158,15 @@ export const fetchPlanetById = async (planetId: number): Promise<PlanetRow> => {
 export const fetchPlanetByName = async (name: string): Promise<PlanetRow> => {
   const payload = await http<unknown>(`/planets/by-name/${encodeURIComponent(name)}`)
   return PlanetRowSchema.parse(payload)
+}
+
+/**
+ * Soft deletes a planet from the catalogue.
+ *
+ * @param planetId - Identifier of the planet to remove.
+ */
+export const softDeletePlanet = async (planetId: number): Promise<void> => {
+  await http<void>(`/planets/${planetId}`, withAdminAuth({ method: 'DELETE' }))
 }
 
 /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -134,6 +134,19 @@ export interface PlanetStats {
   [key: string]: unknown
 }
 
+/** Payload accepted by the `POST /planets/` endpoint when creating a planet. */
+export interface PlanetCreateInput {
+  name: string
+  disc_year?: number
+  disc_method?: string
+  orbperd?: number
+  rade?: number
+  masse?: number
+  st_teff?: number
+  st_rad?: number
+  st_mass?: number
+}
+
 /** Schema describing the raw statistics payload. */
 export const PlanetStatsSchema = z
   .record(z.string(), z.any())

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+export {}
+
+declare global {
+  interface ImportMetaEnv {
+    readonly [key: string]: string | undefined
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "baseUrl": ".",
-    "types": [
-      "vite/client"
-    ]
+    "baseUrl": "."
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary
- remove the discovery timeline and method breakdown sections that were erroring
- refresh the dashboard metrics to focus on discovery years and host star temperatures
- add inline forms that call the POST /planets/ and DELETE /planets/{planet_id} endpoints for quick catalogue management
- expose new client helpers for creating and deleting planets and add local vite env typings

## Testing
- npm run lint *(fails: missing eslint flat config because dependencies cannot be installed without registry access)*
- npm run typecheck *(fails: project dependencies such as React and Vite types are unavailable because npm install is blocked by the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d02c37cc90832a94bc9994b59c3bf7