### PR TITLE
Enhance dashboard metrics and visualisations

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,9 +3,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ErrorState } from '../components/ErrorState'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { MetricCard } from '../components/MetricCard'
-import { createPlanet, softDeletePlanet } from '../api/client'
-import { usePlanetCount, usePlanetStats } from '../hooks/usePlanets'
+import { BarChart } from '../components/BarChart'
+import { TimelineChart } from '../components/TimelineChart'
+import { createPlanet, fetchPlanetByName, softDeletePlanet } from '../api/client'
+import { useMethodCounts, usePlanetCount, usePlanetStats, usePlanetTimeline } from '../hooks/usePlanets'
 import type { PlanetCreateInput } from '../api/types'
+import type { PlanetTimelinePoint, PlanetRow } from '../api/types'
 
 const numberFormatter = new Intl.NumberFormat('en-US')
 const kpiGridStyle: React.CSSProperties = {
@@ -21,13 +24,20 @@ const sectionStyle: React.CSSProperties = {
   marginTop: '2rem',
 }
 
-const buttonStyle: React.CSSProperties = {
+const primaryButtonStyle: React.CSSProperties = {
   background: 'linear-gradient(135deg, #38bdf8, #6366f1)',
   color: '#0f172a',
   fontWeight: 600,
 }
 
+const secondaryButtonStyle: React.CSSProperties = {
+  background: 'rgba(148, 163, 184, 0.2)',
+  color: '#e2e8f0',
+  fontWeight: 500,
+}
+
 const cardPlaceholder = <LoadingSkeleton height="4.5rem" />
+const chartPlaceholder = <LoadingSkeleton height="20rem" />
 
 const toNumber = (value: string): number | undefined => {
   const parsed = Number(value)
@@ -47,6 +57,27 @@ const fieldStyle: React.CSSProperties = {
   fontSize: '0.9rem',
 }
 
+const inlineFieldStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  fontSize: '0.85rem',
+}
+
+const visualisationGridStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: '1.5rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+}
+
+const timelineControlsStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '1rem',
+  flexWrap: 'wrap',
+  alignItems: 'flex-end',
+  justifyContent: 'flex-start',
+}
+
 const helperTextStyle: React.CSSProperties = {
   color: 'rgba(226, 232, 240, 0.6)',
   fontSize: '0.8rem',
@@ -61,14 +92,31 @@ const helperTextStyle: React.CSSProperties = {
 const DashboardPage = () => {
   const queryClient = useQueryClient()
   const [createForm, setCreateForm] = useState({ name: '', disc_method: '', disc_year: '' })
-  const [deleteForm, setDeleteForm] = useState({ planetId: '' })
+  const [deleteForm, setDeleteForm] = useState({ planetName: '' })
   const [createFormError, setCreateFormError] = useState<string | null>(null)
   const [deleteFormError, setDeleteFormError] = useState<string | null>(null)
   const [createdPlanetName, setCreatedPlanetName] = useState<string | null>(null)
-  const [deletedPlanetId, setDeletedPlanetId] = useState<number | null>(null)
+  const [deletedPlanet, setDeletedPlanet] = useState<Pick<PlanetRow, 'id' | 'name'> | null>(null)
+  const [timelineFilters, setTimelineFilters] = useState({ startYear: '', endYear: '' })
 
   const countQuery = usePlanetCount()
   const statsQuery = usePlanetStats()
+  const methodCountsQuery = useMethodCounts()
+
+  const timelineParams = useMemo(() => {
+    const start = toNumber(timelineFilters.startYear)
+    const end = toNumber(timelineFilters.endYear)
+    const params: { start_year?: number; end_year?: number } = {}
+    if (typeof start === 'number') {
+      params.start_year = start
+    }
+    if (typeof end === 'number') {
+      params.end_year = end
+    }
+    return params
+  }, [timelineFilters])
+
+  const timelineQuery = usePlanetTimeline(timelineParams)
 
   const createPlanetMutation = useMutation({
     mutationFn: async (input: PlanetCreateInput) => createPlanet(input),
@@ -81,19 +129,22 @@ const DashboardPage = () => {
   })
 
   const deletePlanetMutation = useMutation({
-    mutationFn: async (planetId: number) => softDeletePlanet(planetId),
-    onSuccess: (_data, planetId) => {
-      setDeleteForm({ planetId: '' })
+    mutationFn: async (planetName: string) => {
+      const planet = await fetchPlanetByName(planetName)
+      await softDeletePlanet(planet.id)
+      return planet
+    },
+    onSuccess: (planet) => {
+      setDeleteForm({ planetName: '' })
       setDeleteFormError(null)
-      setDeletedPlanetId(planetId)
+      setDeletedPlanet({ id: planet.id, name: planet.name })
       void queryClient.invalidateQueries({ queryKey: ['planets'] })
     },
   })
 
   const cards = useMemo(() => {
     const count = countQuery.data?.total
-    const newest = statsQuery.data?.disc_year?.max
-    const earliest = statsQuery.data?.disc_year?.min
+    const medianTeff = statsQuery.data?.st_teff?.median
     const avgTeff = statsQuery.data?.st_teff?.avg ?? statsQuery.data?.st_teff?.mean
 
     return [
@@ -104,15 +155,12 @@ const DashboardPage = () => {
         loading: countQuery.isLoading,
       },
       {
-        title: 'Newest discovery year',
-        value: typeof newest === 'number' ? numberFormatter.format(newest) : '—',
-        hint: 'Latest confirmed discovery in the catalogue',
-        loading: statsQuery.isLoading,
-      },
-      {
-        title: 'Earliest discovery year',
-        value: typeof earliest === 'number' ? numberFormatter.format(earliest) : '—',
-        hint: 'First recorded discovery present in the dataset',
+        title: 'Median host star temperature',
+        value:
+          typeof medianTeff === 'number'
+            ? `${numberFormatter.format(Math.round(medianTeff))} K`
+            : '—',
+        hint: 'Median effective temperature of known host stars',
         loading: statsQuery.isLoading,
       },
       {
@@ -152,17 +200,28 @@ const DashboardPage = () => {
     void createPlanetMutation.mutateAsync(payload)
   }
 
+  const methodChartData = useMemo(
+    () =>
+      (methodCountsQuery.data ?? [])
+        .slice()
+        .sort((a, b) => b.count - a.count)
+        .map((item) => ({ name: item.method, value: item.count })),
+    [methodCountsQuery.data],
+  )
+
+  const timelineData: PlanetTimelinePoint[] = timelineQuery.data ?? []
+
   const handleDeleteSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const parsedId = toNumber(deleteForm.planetId)
-    if (typeof parsedId !== 'number') {
-      setDeleteFormError('Enter a valid numeric planet ID.')
+    const name = deleteForm.planetName.trim()
+    if (name.length === 0) {
+      setDeleteFormError('Enter the planet name you wish to remove.')
       return
     }
 
     setDeleteFormError(null)
-    setDeletedPlanetId(null)
-    void deletePlanetMutation.mutateAsync(parsedId)
+    setDeletedPlanet(null)
+    void deletePlanetMutation.mutateAsync(name)
   }
 
   return (
@@ -180,10 +239,14 @@ const DashboardPage = () => {
           error={countQuery.error ?? statsQuery.error}
           title="Unable to load dashboard metrics"
           action={
-            <button style={buttonStyle} onClick={() => {
-              void countQuery.refetch()
-              void statsQuery.refetch()
-            }}
+            <button
+              style={primaryButtonStyle}
+              onClick={() => {
+                void countQuery.refetch()
+                void statsQuery.refetch()
+                void methodCountsQuery.refetch()
+                void timelineQuery.refetch()
+              }}
             >
               Retry
             </button>
@@ -273,7 +336,7 @@ const DashboardPage = () => {
               </p>
             ) : null}
 
-            <button type="submit" style={buttonStyle} disabled={createPlanetMutation.isPending}>
+            <button type="submit" style={primaryButtonStyle} disabled={createPlanetMutation.isPending}>
               {createPlanetMutation.isPending ? 'Creating…' : 'Create planet'}
             </button>
           </form>
@@ -282,21 +345,19 @@ const DashboardPage = () => {
             <div>
               <h3 style={{ margin: '0 0 0.5rem' }}>Remove a planet</h3>
               <p style={helperTextStyle}>
-                Enter the numeric identifier of the planet you want to soft delete.
+                Enter the planet name to look up its identifier and soft delete the record.
               </p>
             </div>
 
             <label style={fieldStyle}>
-              Planet ID
+              Planet name
               <input
-                type="number"
-                inputMode="numeric"
-                min="1"
-                value={deleteForm.planetId}
+                type="text"
+                value={deleteForm.planetName}
                 onChange={(event) =>
-                  setDeleteForm((state) => ({ ...state, planetId: event.target.value }))
+                  setDeleteForm((state) => ({ ...state, planetName: event.target.value }))
                 }
-                placeholder="1024"
+                placeholder="Kepler-22b"
               />
             </label>
 
@@ -310,14 +371,119 @@ const DashboardPage = () => {
             ) : null}
             {deletePlanetMutation.isSuccess ? (
               <p style={{ ...helperTextStyle, color: '#34d399' }} role="status">
-                Planet {deletedPlanetId ?? ''} removed successfully.
+                Planet
+                {deletedPlanet ? (
+                  <>
+                    {' '}
+                    <strong>{deletedPlanet.name}</strong> (ID {deletedPlanet.id})
+                  </>
+                ) : (
+                  ' entry'
+                )}
+                {' '}removed successfully.
               </p>
             ) : null}
 
-            <button type="submit" style={buttonStyle} disabled={deletePlanetMutation.isPending}>
+            <button type="submit" style={primaryButtonStyle} disabled={deletePlanetMutation.isPending}>
               {deletePlanetMutation.isPending ? 'Removing…' : 'Delete planet'}
             </button>
           </form>
+        </div>
+      </section>
+
+      <section style={sectionStyle}>
+        <div>
+          <h2 style={{ margin: 0 }}>Discovery insights</h2>
+          <p style={{ color: 'rgba(226, 232, 240, 0.7)', margin: 0 }}>
+            Visualise annual discovery rates and the most common detection methods.
+          </p>
+        </div>
+
+        <div style={visualisationGridStyle}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: '1rem', flexWrap: 'wrap' }}>
+              <div>
+                <h3 style={{ margin: 0 }}>Discovery timeline</h3>
+                <p style={helperTextStyle}>Annual counts sourced from <code>GET /planets/timeline</code>.</p>
+              </div>
+              <div style={timelineControlsStyle}>
+                <label style={inlineFieldStyle}>
+                  Start year
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="1995"
+                    value={timelineFilters.startYear}
+                    onChange={(event) =>
+                      setTimelineFilters((state) => ({ ...state, startYear: event.target.value }))
+                    }
+                    min="0"
+                  />
+                </label>
+                <label style={inlineFieldStyle}>
+                  End year
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    placeholder="2024"
+                    value={timelineFilters.endYear}
+                    onChange={(event) =>
+                      setTimelineFilters((state) => ({ ...state, endYear: event.target.value }))
+                    }
+                    min="0"
+                  />
+                </label>
+                {(timelineFilters.startYear || timelineFilters.endYear) && (
+                  <button
+                    type="button"
+                    style={secondaryButtonStyle}
+                    onClick={() => setTimelineFilters({ startYear: '', endYear: '' })}
+                  >
+                    Clear filters
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {timelineQuery.isError ? (
+              <ErrorState
+                error={timelineQuery.error}
+                title="Unable to load discovery timeline"
+                action={
+                  <button style={primaryButtonStyle} onClick={() => void timelineQuery.refetch()}>
+                    Retry
+                  </button>
+                }
+              />
+            ) : timelineQuery.isLoading ? (
+              chartPlaceholder
+            ) : (
+              <TimelineChart data={timelineData} />
+            )}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <div>
+              <h3 style={{ margin: 0 }}>Discovery methods</h3>
+              <p style={helperTextStyle}>Breakdown from <code>GET /planets/method-counts</code>.</p>
+            </div>
+
+            {methodCountsQuery.isError ? (
+              <ErrorState
+                error={methodCountsQuery.error}
+                title="Unable to load discovery methods"
+                action={
+                  <button style={primaryButtonStyle} onClick={() => void methodCountsQuery.refetch()}>
+                    Retry
+                  </button>
+                }
+              />
+            ) : methodCountsQuery.isLoading ? (
+              chartPlaceholder
+            ) : (
+              <BarChart data={methodChartData} title="Planets by discovery method" />
+            )}
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- surface updated KPI cards including median host star temperatures instead of earliest/newest discovery years
- connect the catalogue management forms to the live API with planet deletion by name lookup
- add discovery timeline and method visualisations powered by the timeline and method-count endpoints

## Testing
- pnpm lint *(fails: unable to install dependencies from registry due to 403)*
- pnpm typecheck *(fails: missing React typings because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f67c33c832a81fd97759c8314b2